### PR TITLE
eliminate unnecessary hook usage

### DIFF
--- a/gamemode/core/sv_player.lua
+++ b/gamemode/core/sv_player.lua
@@ -18,7 +18,6 @@ function GM:PlayerLoadout(ply)
 	return true
 end
 
-function BlockSuicide(ply)
-	return false
+function GM:CanPlayerSuicide()
+	return false	
 end
-hook.Add("CanPlayerSuicide", "boiguhs_suicide", BlockSuicide)


### PR DESCRIPTION
other canplayersuicide hooks won't break anymore as opposed to previous method